### PR TITLE
Set only the error levels, and not replace the whole setting

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -1,5 +1,5 @@
 module.exports = require('eslint-config-airbnb-base/rules/best-practices');
 
-module.exports['rules']['no-case-declarations'] = 0;
-module.exports['rules']['no-param-reassign'] = 0;
+module.exports['rules']['no-case-declarations'][0] = 0;
+module.exports['rules']['no-param-reassign'][0] = 0;
 module.exports['rules']['no-unused-expressions'] = [2, { allowShortCircuit: true, allowTernary: true }];

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -1,3 +1,3 @@
 module.exports = require('eslint-config-airbnb-base/rules/errors');
 
-module.exports['rules']['comma-dangle'] = 0;
+module.exports['rules']['comma-dangle'][0] = 0;

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -1,8 +1,8 @@
 module.exports = require('eslint-config-airbnb-base/rules/es6');
 
-module.exports['rules']['array-body-style'] = 0;
-module.exports['rules']['no-useless-constructor'] = 0;
-module.exports['rules']['object-shorthand'] = 0;
-module.exports['rules']['prefer-arrow-callback'] = 0;
-module.exports['rules']['prefer-const'] = 0;
-module.exports['rules']['prefer-template'] = 0;
+module.exports['rules']['arrow-body-style'][0] = 0;
+module.exports['rules']['no-useless-constructor'][0] = 0;
+module.exports['rules']['object-shorthand'][0] = 0;
+module.exports['rules']['prefer-arrow-callback'][0] = 0;
+module.exports['rules']['prefer-const'][0] = 0;
+module.exports['rules']['prefer-template'][0] = 0;

--- a/rules/style.js
+++ b/rules/style.js
@@ -1,6 +1,6 @@
 module.exports = require('eslint-config-airbnb-base/rules/style');
 
-module.exports['rules']['indent'] = 2;
+module.exports['rules']['indent'][0] = 2;
 module.exports['rules']['max-len'] = [0, 10, 4, { ignoreUrls: true }];
 module.exports['rules']['operator-linebreak'] = [1, 'after', {
   overrides: {
@@ -12,6 +12,6 @@ module.exports['rules']['operator-linebreak'] = [1, 'after', {
     '+': 'ignore'
   }
 }];
-module.exports['rules']['quotes'] = 0;
+module.exports['rules']['quotes'][0] = 0;
 module.exports['rules']['quote-props'] = [0, 'consistent'];
 module.exports['rules']['strict'] = 0;


### PR DESCRIPTION
Without using the `[0]` accessor, we weren't just modifying the error level, but we were completely overwriting the base settings coming from airbnb.