### PR TITLE
Enforce the rule 'curly'

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -14,4 +14,5 @@ module.exports['rules']['operator-linebreak'] = [1, 'after', {
 }];
 module.exports['rules']['quotes'][0] = 0;
 module.exports['rules']['quote-props'] = [0, 'consistent'];
+module.exports['rules']['curly'] = [2, 'all'];
 module.exports['rules']['strict'] = 0;

--- a/test/test.js
+++ b/test/test.js
@@ -24,3 +24,12 @@ test('main', (t) => {
     t.is(errors[0].ruleId, 'no-console');
     t.is(errors[1].ruleId, 'semi');
 });
+
+test('travix-specific', (t) => {
+    const conf = require('../');
+
+    const errors = runEslint('if (err) alert(\'curly\');', conf);
+
+    // These are Travix-specific errors, which don't come from airbnb, so this tests if our custom rules are picked up.
+    t.is(errors[0].ruleId, 'curly');
+});


### PR DESCRIPTION
With this PR we disallow code like
```
if (err) return panicError(err, 1);
```
or
```
if (err)
  return panicError(err, 1);
```
There is also a new unit test which verifies (with this `curly` rule) if our custom style rules are picked up.