### PR TITLE
Change to rule curly to a warning

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -14,5 +14,5 @@ module.exports['rules']['operator-linebreak'] = [1, 'after', {
 }];
 module.exports['rules']['quotes'][0] = 0;
 module.exports['rules']['quote-props'] = [0, 'consistent'];
-module.exports['rules']['curly'] = [2, 'all'];
+module.exports['rules']['curly'] = [1, 'all'];
 module.exports['rules']['strict'] = 0;

--- a/test/test.js
+++ b/test/test.js
@@ -32,4 +32,5 @@ test('travix-specific', (t) => {
 
     // These are Travix-specific errors, which don't come from airbnb, so this tests if our custom rules are picked up.
     t.is(errors[0].ruleId, 'curly');
+    t.is(errors[0].severity, 1);
 });


### PR DESCRIPTION
In order not to break builds, we first introduce a warning and release a minor.  
Later we can make it more strict and release a major.