### PR TITLE
Removes peer dependencies for npm >= 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@
 $ npm install --save-dev eslint eslint-config-travix
 ```
 
-For ES6 you'll also need Babel's ESLint [parser](https://github.com/babel/babel-eslint) and [plugin](https://github.com/babel/eslint-plugin-babel):
+For ES6 you'll also need Babel's [Core](https://www.npmjs.com/package/babel-core), ESLint [parser](https://github.com/babel/babel-eslint)
+and [plugin](https://github.com/babel/eslint-plugin-babel):
 
 ```
-$ npm install --save-dev babel-eslint eslint-plugin-babel eslint-plugin-import
+$ npm install --save-dev babel-core babel-eslint eslint-plugin-babel eslint-plugin-import
 ```
 
 For `react`, you will also need `eslint-plugin-react`:

--- a/README.md
+++ b/README.md
@@ -23,14 +23,6 @@ For `react`, you will also need `eslint-plugin-react`:
 $ npm install --save-dev eslint-plugin-react
 ```
 
-### Note for npm v2.x
-
-If you are still using npm v2.x, then just installing the package would bring in all other peer dependencies for you automatically:
-
-```js
-$ npm install --save eslint-config-travix
-```
-
 ## Usage
 
 Add some ESLint config to your `package.json`:

--- a/package.json
+++ b/package.json
@@ -28,14 +28,6 @@
     "deep-assign": "^2.0.0",
     "eslint-config-airbnb-base": "^4.0.2"
   },
-  "peerDependencies": {
-    "babel-core": "^6.10.4",
-    "babel-eslint": "^6.1.2",
-    "eslint": "^3.1.0",
-    "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-import": "^1.11.0",
-    "eslint-plugin-react": "^5.2.2"
-  },
   "devDependencies": {
     "ava": "^0.15.2",
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
# BREAKING CHANGES IN THIS PR
# What does this PR do:
- Removes the peerDependencies from our package.json.
- Removes the indication on the `README.md` that if you're using npm 2.x is fine. It won't be. You will have to install the peerDependencies by hand.

In the end, `babel` should be optional, since not all projects should use babel. Specially with node 6.
# Where should the reviewer start:
- Diffs
# Unit and/or functional tests:

N/A
