### PR TITLE
Update eslint-plugin-react to 6.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,10 @@ module.exports = {
     './base',
     './react'
   ].map(require.resolve),
-  rules: {}
+  rules: {},
+  settings: {
+    react: {
+      pragma: 'React'
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^3.1.0",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^1.11.0",
-    "eslint-plugin-react": "^5.2.2",
+    "eslint-plugin-react": "^6.5.0",
     "is-plain-obj": "^1.1.0",
     "temp-write": "^2.1.0"
   },

--- a/react.js
+++ b/react.js
@@ -122,11 +122,11 @@ module.exports = {
 
     // Prevent usage of setState in componentDidMount
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
-    'react/no-did-mount-set-state': [2, 'allow-in-func'],
+    'react/no-did-mount-set-state': [2],
 
     // Prevent usage of setState in componentDidUpdate
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
-    'react/no-did-update-set-state': [2, 'allow-in-func'],
+    'react/no-did-update-set-state': [2],
 
     // Prevent direct mutation of this.state
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md

--- a/react.js
+++ b/react.js
@@ -205,7 +205,7 @@ module.exports = {
 
     // Prevent missing parentheses around multilines JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md
-    'react/wrap-multilines': [2, {
+    'react/jsx-wrap-multilines': [2, {
       declaration: true,
       assignment: true,
       return: true

--- a/react.js
+++ b/react.js
@@ -105,7 +105,7 @@ module.exports = {
 
     // Prevent React to be incorrectly marked as unused
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
-    'react/jsx-uses-react': [2, { pragma: 'React' }],
+    'react/jsx-uses-react': [2],
 
     // Prevent variables used in JSX to be incorrectly marked as unused
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md


### PR DESCRIPTION
# What does this PR do:

* Since `eslint-plugin-react`s 6.0 version that the rule `react/jsx-uses-react` moved the `pragma` argument to the global `settings.react`
* Updates the `eslint-config-travix` to use the latest `eslint-plugin-react`
* The mode `allow-in-func` is enabled by default in `no-did-mount-set-state` and `no-did-update-set-state` rules since v6.0 of `eslint-plugin-react`
* Renames the rule `wrap-multilines` to `jsx-wrap-multilines` as `wrap-multilines` rule is being deprecated since v6.0 of `eslint-plugin-react`

# Where should the reviewer start:
  - Diffs
  - Do `npm install` and `npm test`

# Unit and/or functional tests:
All passing.