### PR TITLE
Disable linebreak-style rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-travix",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "ESLint config for Travix",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-travix",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "description": "ESLint config for Travix",
   "main": "index.js",
   "scripts": {

--- a/rules/style.js
+++ b/rules/style.js
@@ -16,3 +16,4 @@ module.exports['rules']['quotes'][0] = 0;
 module.exports['rules']['quote-props'] = [0, 'consistent'];
 module.exports['rules']['curly'] = [1, 'all'];
 module.exports['rules']['strict'] = 0;
+module.exports['rules']['linebreak-style'] = 0;


### PR DESCRIPTION
This is a continuation to [the issue discussed in Frint repository](https://github.com/Travix-International/frint/issues/285).

To summarize, we reduce the constraints that are placed on line ending characters in order to allow developers to decide whether to use `LF` or `CRLF` in their local repositories (to better support Windows users). Note that this does not affect the code in remote repositories where line endings are still always expected to be in `LF`. Usually, for Windows devs, Git will ensure that any `CRLF` is converted to `LF` on `git push`.

Consumers of this ESLint configuration have the opportunity to override this rule in their repository if needed.

https://eslint.org/docs/rules/linebreak-style