### PR TITLE
patch: Don't enforce lines between single line class members

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'plugin:jsx-a11y/recommended',
   ],
   rules: {
+    'lines-between-class-members': ['error', 'always', { 'exceptAfterSingleLine': true }],
     'max-len': ['error', {
       'code': 120,
       'ignoreStrings': true,


### PR DESCRIPTION
This is specially useful when writing TypeScript, where you have to declare all class members at the top of the class.