### PR TITLE
patch: Add ranges to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "simple-commit-message": "4.0.3"
   },
   "peerDependencies": {
-    "eslint-config-airbnb": "17.1.0",
-    "eslint-plugin-import": "2.14.0",
-    "eslint-plugin-jsx-a11y": "6.1.1",
-    "eslint-plugin-react": "7.11.1"
+    "eslint-config-airbnb": "^17.1.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-jsx-a11y": "^6.1.1",
+    "eslint-plugin-react": "^7.11.1"
   },
   "release": {
     "analyzeCommits": "simple-commit-message",


### PR DESCRIPTION
Add ranges to peer dependencies, to avoid `npm ERR! peer dep missing` errors in consumers. From [npm docs](https://docs.npmjs.com/files/package.json#peerdependencies):

> Trying to install another plugin with a conflicting requirement will cause an error. For this reason, make sure your plugin requirement is as broad as possible, and not to lock it down to specific patch versions.
