### PR TITLE
minor: Decrease `max-len` to 100 characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
   rules: {
     'lines-between-class-members': ['error', 'always', { 'exceptAfterSingleLine': true }],
     'max-len': ['error', {
-      'code': 120,
+      'code': 100,
       'ignoreStrings': true,
       'ignoreTemplateLiterals': true,
       'ignoreUrls': true,


### PR DESCRIPTION
When used together with `prettier-eslint`, a `max-len` rule of 120 characters may produce undesirable results. From [Prettier docs](https://prettier.io/docs/en/options.html#print-width):

> Prettier [...] strives to fit the most code into every line. With the print width set to 120, prettier may produce overly compact, or otherwise undesirable code.

This PR decreases the `max-len` value to 100 characters, which should improve formatting.