### PR TITLE
minor: Change `react/sort-comp` order

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,16 @@ module.exports = {
     'react/forbid-prop-types': ['error', { 'forbid': ['any'] }],
     'react/jsx-sort-props': ['error'],
     'react/jsx-filename-extension': ['error', { 'extensions': ['.js'] }],
-    "react/jsx-one-expression-per-line": 'off',
+    'react/jsx-one-expression-per-line': 'off',
+    'react/sort-comp': ['error', {
+      'order': [
+        'static-methods',
+        'type-annotations',
+        'instance-variables',
+        'lifecycle',
+        'everything-else',
+        'render'
+      ]
+    }]
   }
 };


### PR DESCRIPTION
The default `order` configuration for `react/sort-comp` is

```js
[
  'static-methods',
  'lifecycle',
  'everything-else',
  'render'
]
```

which forces type annotations and instance variables to be placed between lifecycle methods and the render method.

This PR adds type annotations and instance variables to the configuration, so they can be declared at the top of the class, right after static members.