### PR TITLE
fix: Ignore class field declarations for React destructuring assignments

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,21 +17,22 @@ module.exports = {
     'plugin:jsx-a11y/recommended',
   ],
   rules: {
-    'lines-between-class-members': ['error', 'always', { 'exceptAfterSingleLine': true }],
+    'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
     'max-len': ['error', {
-      'code': 100,
-      'ignoreStrings': true,
-      'ignoreTemplateLiterals': true,
-      'ignoreUrls': true,
-      'ignoreTrailingComments': true,
-      'ignoreRegExpLiterals': true
+      code: 100,
+      ignoreStrings: true,
+      ignoreTemplateLiterals: true,
+      ignoreUrls: true,
+      ignoreTrailingComments: true,
+      ignoreRegExpLiterals: true
     }],
-    'react/forbid-prop-types': ['error', { 'forbid': ['any'] }],
+    'react/destructuring-assignment': ['error', 'always', { ignoreClassFields: true }],
+    'react/forbid-prop-types': ['error', { forbid: ['any'] }],
     'react/jsx-sort-props': ['error'],
-    'react/jsx-filename-extension': ['error', { 'extensions': ['.js'] }],
+    'react/jsx-filename-extension': ['error', { extensions: ['.js'] }],
     'react/jsx-one-expression-per-line': 'off',
     'react/sort-comp': ['error', {
-      'order': [
+      order: [
         'static-methods',
         'type-annotations',
         'instance-variables',


### PR DESCRIPTION
[Ignore class field declarations](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md#ignoreclassfields) for destructuring assignment of props, state, and context:

```js
'react/destructuring-assignment': ['error', 'always', { ignoreClassFields: true }]
```

The following patterns are then considered okay and do not cause warnings:

```js
class Foo extends React.PureComponent {
  bar = this.props.bar
}
```