### PR TITLE
minor: Enforce the Rules of Hooks for React

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1690,6 +1690,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.3.0.tgz",
+      "integrity": "sha512-hjgyNq0sfDXaLkXHkmo3vRh+p+42lwQIU3r56hVoomMYRMToJ2D/PGhwL2EPyB5ZEMlbLsRm3s5v4gm5FIjlvg==",
+      "dev": true
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jsx-a11y": "6.1.1",
     "eslint-plugin-react": "7.11.1",
+    "eslint-plugin-react-hooks": "1.3.0",
     "rimraf": "2.6.3",
     "semantic-release": "15.13.4",
     "simple-commit-message": "4.0.3",
@@ -48,7 +49,8 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-react-hooks": "^1.3.0"
   },
   "release": {
     "analyzeCommits": "simple-commit-message",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,8 @@ const config: object = {
         'render',
       ],
     }],
+    'react-hooks/exhaustive-deps': 'error',
+    'react-hooks/rules-of-hooks': 'error',
   },
 };
 


### PR DESCRIPTION
### What this PR does

Enforce the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html), part of the [Hooks API](https://reactjs.org/docs/hooks-intro.html) for React.

- Add `react-hooks` ESLint plugin to dev and peer dependencies
- Enable `exhaustive-deps` and `rules-of-hooks` rules