### PR TITLE
minor: Add max-params rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ const config: object = {
       ignoreTrailingComments: true,
       ignoreUrls: true,
     }],
+    'max-params': ['error', 3],
     'prefer-destructuring': ['error', {
       array: true,
       object: true,


### PR DESCRIPTION
## What does this PR do:
* Added the `max-params` rule to limit the number of function's argument to 3. ([The rule's description](https://eslint.org/docs/rules/max-params))