### PR TITLE
fix: Allow state initialization outside constructor and static public fields inside class body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,8 @@ const config: object = {
         'render',
       ],
     }],
-    'react/state-in-constructor': 'off'
+    'react/state-in-constructor': 'off',
+    'react/static-property-placement': ['error', 'static public field'],
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ const config: object = {
         'render',
       ],
     }],
+    'react/state-in-constructor': 'off'
   },
 };
 


### PR DESCRIPTION
## What this PR does

- Allow state initialization in constructor or with class property (disable [`react/state-in-constructor`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md) rule)
- Allow static public fields inside class body (the default for [`react/static-property-placement`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/static-property-placement.md), overridden by Airbnb config)